### PR TITLE
fix: re-enable @typescript-eslint/semi

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,7 +49,7 @@
     "@typescript-eslint/require-array-sort-compare": "error",
     "@typescript-eslint/restrict-plus-operands": "error",
     "semi": "off",
-    // "@typescript-eslint/semi": ["error", "never"],
+    "@typescript-eslint/semi": ["error", "never"],
     "@typescript-eslint/type-annotation-spacing": "error",
     "@typescript-eslint/unbound-method": "error"
   },


### PR DESCRIPTION
It turns out this was automatically fixed by eslint earlier which means this PR will simply re-enable the rule.