### PR TITLE
fix: re-enable @typescript-eslint/no-for-in-array

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     "@typescript-eslint/no-empty-interface": "error",
     // "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-extraneous-class": "error",
-    // "@typescript-eslint/no-for-in-array": "error",
+    "@typescript-eslint/no-for-in-array": "error",
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/no-misused-new": "error",
     "@typescript-eslint/no-namespace": "error",


### PR DESCRIPTION
This was fixed automatically and we are re-enabling the rule. Fixes #25.