### PR TITLE
fix: re-enable explicit-function-return-type and no-require-imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,16 +17,16 @@
       "error",
       {"accessibility": "no-public"}
     ],
-    // "@typescript-eslint/no-require-imports": "error",
+    "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/await-thenable": "error",
     "@typescript-eslint/ban-ts-comment": "error",
     "camelcase": "off",
     "@typescript-eslint/consistent-type-assertions": "error",
-    // "@typescript-eslint/explicit-function-return-type": [
-    //   "error",
-    //   {"allowExpressions": true}
-    // ],
+    "@typescript-eslint/explicit-function-return-type": [
+      "error",
+      {"allowExpressions": true}
+    ],
     "@typescript-eslint/func-call-spacing": ["error", "never"],
     "@typescript-eslint/no-array-constructor": "error",
     "@typescript-eslint/no-empty-interface": "error",


### PR DESCRIPTION
Again, this was handled during initial migration itself. Fixes #21 and #22.