### PR TITLE
ci: do not run auto commit in pull requests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -27,6 +27,7 @@ jobs:
     - run: npm run all
 
     - uses: stefanzweifel/git-auto-commit-action@v5
+      if: github.event_name != 'pull_request'
       with:
         commit_message: Add prepared script
         commit_options: '--no-verify --signoff'


### PR DESCRIPTION
This is to avoid failures like the one we saw in #126. The job fails because it is a pull request from a fork and it cannot commit to the source repository. It turns out we don't really need to auto-commit in PR. The job will still run once the PR is merged but now it will run in the context of the actual repo.