### PR TITLE
feat: Update default PHP version to 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # GitHub Action for DrupalQA
 
+[![GitHub Super-Linter](https://github.com/hussainweb/drupalqa-action/actions/workflows/linter.yml/badge.svg)](https://github.com/super-linter/super-linter)
+![CI](https://github.com/hussainweb/drupalqa-action/actions/workflows/ci.yml/badge.svg)
+[![Check dist/](https://github.com/hussainweb/drupalqa-action/actions/workflows/check-dist.yml/badge.svg)](https://github.com/hussainweb/drupalqa-action/actions/workflows/check-dist.yml)
+[![CodeQL](https://github.com/hussainweb/drupalqa-action/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/hussainweb/drupalqa-action/actions/workflows/codeql-analysis.yml)
+[![Coverage](./badges/coverage.svg)](./badges/coverage.svg)
+
 This action runs checks from [DrupalQA](https://github.com/hussainweb/drupalqa)
 on a Drupal codebase. While you can directly use the Docker image with GitHub
 Actions, this Action makes it simpler to specify and configure some of the
@@ -10,14 +16,14 @@ checks.
 ### `php-version`
 
 The PHP version to use (corresponds to the Docker image). Allowed options and
-their corresponding Docker images are as follows. Default: `8.2`.
+their corresponding Docker images are as follows. Default: `8.4`.
 
 | php-version | Docker image                                 |
 | ----------- | -------------------------------------------- |
 | 7.3         | hussainweb/drupalqa:php7.3 (_not supported_) |
 | 7.4         | hussainweb/drupalqa:php7.4 (_not supported_) |
 | 8.0         | hussainweb/drupalqa:php8.0 (_not supported_) |
-| 8.1         | hussainweb/drupalqa:php8.1                   |
+| 8.1         | hussainweb/drupalqa:php8.1 (_not supported_) |
 | 8.2         | hussainweb/drupalqa:php8.2                   |
 | 8.3         | hussainweb/drupalqa:php8.3                   |
 | 8.4         | hussainweb/drupalqa:php8.4                   |
@@ -61,7 +67,7 @@ No outputs.
 ```yaml
 uses: hussainweb/drupalqa@v1
 with:
-  php-version: 8.2
+  php-version: 8.4
   checks: |
     phplint: {}
     phpcs:

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   php-version: # id of input
     description: 'PHP version.'
     required: false
-    default: '8.2'
+    default: '8.4'
   web-root:
     description:
       'Web root (document root). This is set to web by default. Do not include


### PR DESCRIPTION
This commit updates the default PHP version used by the action to 8.4.
It also updates the README to reflect this change and adds badges for new workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added badges to the README.
  * Updated PHP references to default to 8.4.
  * Clarified support matrix, marking PHP 8.1 as not supported.
  * Updated example usage to PHP 8.4.

* **Chores**
  * Changed the GitHub Action’s default php-version input to 8.4, maintaining existing behavior for users relying on defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->